### PR TITLE
Add response into apigatewayproxyevt

### DIFF
--- a/service/lambda/runtime/event/apigatewayproxyevt/definition.go
+++ b/service/lambda/runtime/event/apigatewayproxyevt/definition.go
@@ -114,7 +114,7 @@ type Event struct {
 	// PUT.
 	HTTPMethod string
 
-	// The incoming reauest HTTP headers.
+	// The incoming request HTTP headers.
 	// Duplicate entries are not supported.
 	Headers map[string]string
 
@@ -160,7 +160,7 @@ type Response struct {
 	// The outgoing HTTP status code.
 	StatusCode int `json:"statusCode"`
 
-	// The outgoing reauest HTTP headers.
+	// The outgoing request HTTP headers.
 	Headers map[string]string `json:"headers"`
 
 	// If used with IsBase64Encoded flag true, it represents the Base64 encoded

--- a/service/lambda/runtime/event/apigatewayproxyevt/definition.go
+++ b/service/lambda/runtime/event/apigatewayproxyevt/definition.go
@@ -151,6 +151,23 @@ type Event struct {
 	RequestContext *RequestContext
 }
 
+// Response represents an API Gateway Lambda Proxy response format.
+type Response struct {
+	// A flag to indicate if the applicable request payload is Base64
+	// encoded.
+	IsBase64Encoded bool `json:"isBase64Encoded"`
+
+	// The outgoing HTTP status code.
+	StatusCode int `json:"statusCode"`
+
+	// The outgoing reauest HTTP headers.
+	Headers map[string]string `json:"headers"`
+
+	// If used with IsBase64Encoded flag true, it represents the Base64 encoded
+	// binary data. Otherwise it represents the raw data.
+	Body string `json:"body"`
+}
+
 // String returns the string representation.
 func (e *Event) String() string {
 	s, _ := json.Marshal(e)


### PR DESCRIPTION
* Add Definition for Api Gateway Proxy response

More detail
* http://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format