### PR TITLE
Add SubscribeURL and Token attributes

### DIFF
--- a/service/lambda/runtime/event/snsevt/definition.go
+++ b/service/lambda/runtime/event/snsevt/definition.go
@@ -67,6 +67,14 @@ type Record struct {
 	// The URL to the certificate that was used to sign the message.
 	SignatureCertURL string
 
+	// The URL that you must visit in order to confirm the subscription.
+	// Alternatively, you can instead use the Token with the ConfirmSubscription action to confirm the subscription.
+	SubscribeURL string
+
+	// A value you can use with the ConfirmSubscription action to confirm the subscription.
+	// Alternatively, you can simply visit the SubscribeURL.
+	Token string
+
 	// The ARN of the topic that this message was published to.
 	TopicARN string
 

--- a/service/lambda/runtime/event/snsevt/definition.go
+++ b/service/lambda/runtime/event/snsevt/definition.go
@@ -68,11 +68,12 @@ type Record struct {
 	SignatureCertURL string
 
 	// The URL that you must visit in order to confirm the subscription.
-	// Alternatively, you can instead use the Token with the ConfirmSubscription action to confirm the subscription.
+	// Alternatively, you can instead use the Token with the
+	// ConfirmSubscription action to confirm the subscription.
 	SubscribeURL string
 
-	// A value you can use with the ConfirmSubscription action to confirm the subscription.
-	// Alternatively, you can simply visit the SubscribeURL.
+	// A value you can use with the ConfirmSubscription action to confirm the
+	// subscription. Alternatively, you can simply visit the SubscribeURL.
 	Token string
 
 	// The ARN of the topic that this message was published to.


### PR DESCRIPTION
Allows a Lambda to auto confirm a subscription to an SNS Topic. 
When it's a target behind an API Gateway: http://docs.aws.amazon.com/sns/latest/dg/SendMessageToHttp.html for example.